### PR TITLE
Add lint step to PR workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
           
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
-        
+
+      - name: Run lint
+        run: pnpm lint
+
       - name: Run tests
         run: pnpm test
+

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:coverage": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js --coverage",
     "test:detect": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js --detectOpenHandles",
     "test:registry": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js test/unit/fred/registry.test.ts",
-    "test:client": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js test/unit/fred/client.test.ts"
+    "test:client": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js test/unit/fred/client.test.ts",
+    "lint": "tsc --noEmit"
   },
   "files": [
     "build"


### PR DESCRIPTION
## Summary
- add `pnpm lint` script that runs the TypeScript compiler with `--noEmit`
- run `pnpm lint` before tests in the CI workflow

## Testing
- `pnpm lint`
- `pnpm test`