### PR TITLE
docs: add AUTHORS and CONTRIBUTORS files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,5 @@
+# Authors
+
+This is the official list of fred-mcp-server authors for copyright purposes.
+
+Stefano Amorelli <stefano@amorelli.tech>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,6 +6,7 @@ This is the list of fred-mcp-server contributors.
 
 Stefano Amorelli <stefano@amorelli.tech>
 Henry Mao <1828968+calclavia@users.noreply.github.com>
+scott goley <scottmgoley@gmail.com>
 
 ## Acknowledgments
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,12 @@
+# Contributors
+
+This is the list of fred-mcp-server contributors.
+
+## Contributors (in order of first contribution)
+
+Stefano Amorelli <stefano@amorelli.tech>
+Henry Mao <1828968+calclavia@users.noreply.github.com>
+
+## Acknowledgments
+
+We thank all contributors who have helped make fred-mcp-server better!


### PR DESCRIPTION
## Summary
- Added AUTHORS file listing primary project authors
- Added CONTRIBUTORS file with all contributors from git history
- Based on actual git commit history

## Purpose
This PR adds proper attribution files to acknowledge all contributors to the fred-mcp-server project

## Files Added
- `AUTHORS`: Lists the primary authors of the project
- `CONTRIBUTORS`: Lists all contributors who have committed to the project