### PR TITLE
fix: support Windows build and entrypoint checks

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -6,7 +6,7 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { registerFREDTools } from "./fred/tools.js";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import { randomUUID } from "crypto";
 import express from "express";
 /**
@@ -175,7 +175,10 @@ async function main() {
     }
 }
 export const TESTING_DISABLED_AUTO_START = false;
-if (import.meta.url === `file://${process.argv[1]}` && !TESTING_DISABLED_AUTO_START) {
+export function isMainModule(moduleUrl, argvPath = process.argv[1]) {
+    return argvPath ? fileURLToPath(moduleUrl) === resolve(argvPath) : false;
+}
+if (isMainModule(import.meta.url) && !TESTING_DISABLED_AUTO_START) {
     main().catch((error) => {
         console.error("Fatal error in main():", error);
         process.exit(1);

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "fred-mcp-server": "./build/index.js"
   },
   "scripts": {
-    "build": "tsc && chmod 755 build/index.js",
+    "build": "tsc && node -e \"if (process.platform !== 'win32') require('fs').chmodSync('build/index.js', 0o755)\"",
     "start": "node build/index.js",
     "release": "release-it",
-    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
+    "test": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js",
     "test:watch": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js --watch",
     "test:coverage": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js --coverage",
     "test:detect": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js --detectOpenHandles",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { registerFREDTools } from "./fred/tools.js";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import { randomUUID } from "crypto";
 import express, { Request, Response } from "express";
 import { Server } from "http";
@@ -205,7 +205,11 @@ async function main() {
 
 export const TESTING_DISABLED_AUTO_START = false;
 
-if (import.meta.url === `file://${process.argv[1]}` && !TESTING_DISABLED_AUTO_START) {
+export function isMainModule(moduleUrl: string, argvPath = process.argv[1]): boolean {
+  return argvPath ? fileURLToPath(moduleUrl) === resolve(argvPath) : false;
+}
+
+if (isMainModule(import.meta.url) && !TESTING_DISABLED_AUTO_START) {
   main().catch((error) => {
     console.error("Fatal error in main():", error);
     process.exit(1);

--- a/src/index.wrapper.ts
+++ b/src/index.wrapper.ts
@@ -82,7 +82,7 @@ async function main() {
 }
 
 // Only run the main function if this file is executed directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (fredServer.isMainModule(import.meta.url)) {
   main().catch((error) => {
     console.error("Fatal error in main():", error);
     process.exit(1);

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, test, jest, beforeEach, afterEach } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
-import { createServer, startServer } from '../../src/index.js';
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { pathToFileURL } from 'url';
+import { isMainModule } from '../../src/index.js';
 
 // Create mock class instead of using jest.mock
 // This avoids ESM module mocking issues
@@ -52,5 +51,14 @@ describe('Server entry point', () => {
 
     // Check for FRED tools registration
     expect(content).toContain('registerFREDTools(server)');
+  });
+
+  test('isMainModule compares file paths instead of file URLs', () => {
+    const argvPath = path.resolve('build/index.js');
+    const moduleUrl = pathToFileURL(argvPath).href;
+
+    expect(isMainModule(moduleUrl, argvPath)).toBe(true);
+    expect(isMainModule(moduleUrl, path.resolve('build/other.js'))).toBe(false);
+    expect(isMainModule(moduleUrl, undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
This PR improves Windows compatibility for local development while preserving the existing Unix behavior.
It fixes two Windows-specific issues:
- The ESM entrypoint check compared `import.meta.url` with a manually constructed `file://` URL from `process.argv[1]`, which does not work reliably with Windows paths.
- The `build` and `test` scripts used POSIX shell-specific syntax, causing failures on Windows.
## Changes
- Add an `isMainModule()` helper that compares normalized file paths instead of manually constructing a `file://` URL.
- Reuse the same entrypoint check in `src/index.wrapper.ts`.
- Update the `build` script to use Node's `fs.chmodSync()` on non-Windows platforms, while skipping chmod on Windows.
- Update the `test` script to invoke Jest through `node` directly instead of using POSIX-style `NODE_OPTIONS='...'`.
- Add a unit test covering the new entrypoint detection behavior.
## Why
The previous implementation worked on Unix-like systems, but failed on Windows because:
- Windows paths such as `C:\...` do not match a manually built `file://...` URL.
- `chmod` is not available in the default Windows shell.
- Single-quoted environment variable assignment in npm scripts is not portable across platforms.
This PR keeps the Unix executable-bit behavior intact by still applying `chmod` on non-Windows platforms, but avoids requiring POSIX shell commands on Windows.
## Verification
Tested locally on Windows:
- `npm run build`
- `npm test -- --runInBand`
All tests passed:
- 9 test suites passed
- 48 tests passed