### PR TITLE
Add release dates, series info, and series tags tools

### DIFF
--- a/src/fred/browse.ts
+++ b/src/fred/browse.ts
@@ -230,6 +230,177 @@ export async function getReleaseSeries(releaseId: number, options: {
 }
 
 /**
+ * Get release dates for a specific release (upcoming and historical)
+ */
+export async function getReleaseDates(releaseId: number, options: {
+  limit?: number;
+  offset?: number;
+  sort_order?: "asc" | "desc";
+  include_release_dates_with_no_data?: boolean;
+} = {}) {
+  try {
+    const queryParams: Record<string, string | number | boolean> = {
+      release_id: releaseId
+    };
+
+    if (options.limit !== undefined) queryParams.limit = options.limit;
+    if (options.offset !== undefined) queryParams.offset = options.offset;
+    if (options.sort_order) queryParams.sort_order = options.sort_order;
+    if (options.include_release_dates_with_no_data !== undefined) {
+      queryParams.include_release_dates_with_no_data = options.include_release_dates_with_no_data;
+    }
+
+    const response = await makeRequest<{
+      count: number;
+      offset: number;
+      limit: number;
+      release_dates: Array<{ release_id: number; date: string }>;
+    }>("release/dates", queryParams);
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          release_id: releaseId,
+          total_dates: response.count,
+          showing: `${response.offset + 1}-${Math.min(response.offset + response.limit, response.count)}`,
+          release_dates: response.release_dates.map(d => d.date)
+        }, null, 2)
+      }]
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to get release dates: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get all upcoming release dates across all releases
+ */
+export async function getAllReleaseDates(options: {
+  limit?: number;
+  offset?: number;
+  sort_order?: "asc" | "desc";
+  include_release_dates_with_no_data?: boolean;
+} = {}) {
+  try {
+    const queryParams: Record<string, string | number | boolean> = {};
+
+    if (options.limit !== undefined) queryParams.limit = options.limit;
+    if (options.offset !== undefined) queryParams.offset = options.offset;
+    if (options.sort_order) queryParams.sort_order = options.sort_order;
+    if (options.include_release_dates_with_no_data !== undefined) {
+      queryParams.include_release_dates_with_no_data = options.include_release_dates_with_no_data;
+    }
+
+    const response = await makeRequest<{
+      count: number;
+      offset: number;
+      limit: number;
+      release_dates: Array<{ release_id: number; release_name: string; date: string }>;
+    }>("releases/dates", queryParams);
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          total_dates: response.count,
+          showing: `${response.offset + 1}-${Math.min(response.offset + response.limit, response.count)}`,
+          release_dates: response.release_dates.map(d => ({
+            release_id: d.release_id,
+            release_name: d.release_name,
+            date: d.date
+          }))
+        }, null, 2)
+      }]
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to get all release dates: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get detailed info about a specific series
+ */
+export async function getSeriesInfo(seriesId: string) {
+  try {
+    const response = await makeRequest<{
+      seriess: Array<{
+        id: string;
+        realtime_start: string;
+        realtime_end: string;
+        title: string;
+        observation_start: string;
+        observation_end: string;
+        frequency: string;
+        frequency_short: string;
+        units: string;
+        units_short: string;
+        seasonal_adjustment: string;
+        seasonal_adjustment_short: string;
+        last_updated: string;
+        popularity: number;
+        notes: string;
+      }>;
+    }>("series", { series_id: seriesId });
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify(response.seriess[0] || {}, null, 2)
+      }]
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to get series info: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get tags for a series
+ */
+export async function getSeriesTags(seriesId: string) {
+  try {
+    const response = await makeRequest<{
+      tags: Array<{
+        name: string;
+        group_id: string;
+        notes: string;
+        created: string;
+        popularity: number;
+        series_count: number;
+      }>;
+    }>("series/tags", { series_id: seriesId });
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          series_id: seriesId,
+          tags: response.tags.map(t => ({
+            name: t.name,
+            group: t.group_id,
+            popularity: t.popularity
+          }))
+        }, null, 2)
+      }]
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to get series tags: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+/**
  * Browse all FRED sources
  */
 export async function browseSources(options: {

--- a/src/fred/tools.ts
+++ b/src/fred/tools.ts
@@ -7,7 +7,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { searchSeries, FREDSearchOptions } from "./search.js";
 import { getSeriesData, FREDSeriesOptions } from "./series.js";
-import { browseCategories, getCategorySeries, browseReleases, getReleaseSeries, browseSources } from "./browse.js";
+import { browseCategories, getCategorySeries, browseReleases, getReleaseSeries, browseSources, getReleaseDates, getAllReleaseDates, getSeriesInfo, getSeriesTags } from "./browse.js";
 
 /**
  * Schema for FRED search tool
@@ -142,6 +142,63 @@ export function registerFREDTools(server: McpServer) {
       const result = await getSeriesData(input as FREDSeriesOptions);
       console.error("fred_get_series complete");
       return result;
+    }
+  );
+
+  // Register release dates tool
+  server.tool(
+    "fred_release_dates",
+    "Get release dates for a specific FRED release (e.g., CPI, Employment Situation, GDP). Use release_id to get dates for a specific release, or omit it to get all upcoming release dates across all releases. Useful for finding when economic data will be published.",
+    {
+      release_id: z.number().optional().describe("Release ID to get dates for. Omit to get all upcoming release dates."),
+      limit: z.number().min(1).max(1000).optional().default(50).describe("Maximum number of dates to return"),
+      offset: z.number().min(0).optional().default(0).describe("Number of results to skip"),
+      sort_order: z.enum(["asc", "desc"]).optional().default("desc").describe("Sort order by date"),
+      include_release_dates_with_no_data: z.boolean().optional().describe("Include dates with no data (future scheduled releases)")
+    },
+    async (input: any) => {
+      console.error(`fred_release_dates called with params: ${JSON.stringify(input)}`);
+      if (input.release_id) {
+        return await getReleaseDates(input.release_id, {
+          limit: input.limit,
+          offset: input.offset,
+          sort_order: input.sort_order,
+          include_release_dates_with_no_data: input.include_release_dates_with_no_data
+        });
+      } else {
+        return await getAllReleaseDates({
+          limit: input.limit,
+          offset: input.offset,
+          sort_order: input.sort_order,
+          include_release_dates_with_no_data: input.include_release_dates_with_no_data
+        });
+      }
+    }
+  );
+
+  // Register series info tool
+  server.tool(
+    "fred_series_info",
+    "Get detailed metadata about a specific FRED series including title, units, frequency, seasonal adjustment, observation range, popularity, and notes.",
+    {
+      series_id: z.string().describe("The FRED series ID (e.g., 'GDP', 'UNRATE', 'CPIAUCSL')")
+    },
+    async (input: any) => {
+      console.error(`fred_series_info called with params: ${JSON.stringify(input)}`);
+      return await getSeriesInfo(input.series_id);
+    }
+  );
+
+  // Register series tags tool
+  server.tool(
+    "fred_series_tags",
+    "Get tags associated with a FRED series. Useful for understanding what categories and classifications a series belongs to.",
+    {
+      series_id: z.string().describe("The FRED series ID (e.g., 'GDP', 'UNRATE')")
+    },
+    async (input: any) => {
+      console.error(`fred_series_tags called with params: ${JSON.stringify(input)}`);
+      return await getSeriesTags(input.series_id);
     }
   );
 }

--- a/test/unit/fred/browse.test.ts
+++ b/test/unit/fred/browse.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test, jest, beforeEach, afterEach, afterAll } from '@jest/globals';
+import { getReleaseDates, getAllReleaseDates, getSeriesInfo, getSeriesTags, browseCategories, browseReleases, browseSources } from '../../../src/fred/browse.js';
+
+// Suppress console.error output during tests
+const originalConsoleError = console.error;
+console.error = jest.fn();
+
+afterAll(() => {
+  console.error = originalConsoleError;
+});
+
+describe('FRED browse module', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('getReleaseDates', () => {
+    test('returns formatted release dates for a specific release', async () => {
+      const mockResponse = {
+        count: 2,
+        offset: 0,
+        limit: 50,
+        release_dates: [
+          { release_id: 10, date: '2026-05-13' },
+          { release_id: 10, date: '2026-04-10' }
+        ]
+      };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      );
+
+      const result = await getReleaseDates(10);
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.release_id).toBe(10);
+      expect(parsed.total_dates).toBe(2);
+      expect(parsed.release_dates).toHaveLength(2);
+      expect(parsed.release_dates[0]).toBe('2026-05-13');
+    });
+
+    test('passes query parameters correctly', async () => {
+      const mockResponse = { count: 0, offset: 0, limit: 10, release_dates: [] };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      );
+
+      await getReleaseDates(10, { limit: 10, sort_order: 'asc', include_release_dates_with_no_data: true });
+
+      const url = (global.fetch as jest.Mock).mock.calls[0][0];
+      expect(url).toContain('release_id=10');
+      expect(url).toContain('limit=10');
+      expect(url).toContain('sort_order=asc');
+      expect(url).toContain('include_release_dates_with_no_data=true');
+    });
+
+    test('throws on API error', async () => {
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve('Not Found') })
+      );
+
+      await expect(getReleaseDates(999)).rejects.toThrow('Failed to get release dates');
+    });
+  });
+
+  describe('getAllReleaseDates', () => {
+    test('returns formatted release dates across all releases', async () => {
+      const mockResponse = {
+        count: 2,
+        offset: 0,
+        limit: 50,
+        release_dates: [
+          { release_id: 10, release_name: 'Consumer Price Index', date: '2026-05-13' },
+          { release_id: 53, release_name: 'Gross Domestic Product', date: '2026-05-29' }
+        ]
+      };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      );
+
+      const result = await getAllReleaseDates();
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.total_dates).toBe(2);
+      expect(parsed.release_dates[0].release_name).toBe('Consumer Price Index');
+      expect(parsed.release_dates[1].date).toBe('2026-05-29');
+    });
+  });
+
+  describe('getSeriesInfo', () => {
+    test('returns series metadata', async () => {
+      const mockResponse = {
+        seriess: [{
+          id: 'GDP',
+          title: 'Gross Domestic Product',
+          frequency: 'Quarterly',
+          units: 'Billions of Dollars',
+          seasonal_adjustment: 'Seasonally Adjusted Annual Rate',
+          last_updated: '2026-04-30',
+          popularity: 95,
+          notes: 'GDP notes'
+        }]
+      };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      );
+
+      const result = await getSeriesInfo('GDP');
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.id).toBe('GDP');
+      expect(parsed.title).toBe('Gross Domestic Product');
+      expect(parsed.frequency).toBe('Quarterly');
+    });
+
+    test('passes series_id as query parameter', async () => {
+      const mockResponse = { seriess: [{ id: 'UNRATE' }] };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      );
+
+      await getSeriesInfo('UNRATE');
+
+      const url = (global.fetch as jest.Mock).mock.calls[0][0];
+      expect(url).toContain('series_id=UNRATE');
+    });
+
+    test('throws on API error', async () => {
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: false, status: 400, text: () => Promise.resolve('Bad Request') })
+      );
+
+      await expect(getSeriesInfo('INVALID')).rejects.toThrow('Failed to get series info');
+    });
+  });
+
+  describe('getSeriesTags', () => {
+    test('returns tags for a series', async () => {
+      const mockResponse = {
+        tags: [
+          { name: 'gdp', group_id: 'gen', notes: '', created: '2012-02-27', popularity: 99, series_count: 100 },
+          { name: 'quarterly', group_id: 'freq', notes: '', created: '2012-02-27', popularity: 80, series_count: 500 }
+        ]
+      };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      );
+
+      const result = await getSeriesTags('GDP');
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.series_id).toBe('GDP');
+      expect(parsed.tags).toHaveLength(2);
+      expect(parsed.tags[0].name).toBe('gdp');
+      expect(parsed.tags[1].group).toBe('freq');
+    });
+
+    test('throws on API error', async () => {
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: false, status: 400, text: () => Promise.resolve('Bad Request') })
+      );
+
+      await expect(getSeriesTags('INVALID')).rejects.toThrow('Failed to get series tags');
+    });
+  });
+
+  describe('browseCategories', () => {
+    test('returns root categories when no id provided', async () => {
+      const mockResponse = {
+        categories: [{ id: 0, name: 'Root', parent_id: 0 }]
+      };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      );
+
+      const result = await browseCategories();
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.categories).toHaveLength(1);
+      expect(parsed.categories[0].name).toBe('Root');
+    });
+  });
+
+  describe('browseReleases', () => {
+    test('returns releases list', async () => {
+      const mockResponse = {
+        count: 1, offset: 0, limit: 50,
+        releases: [{ id: 10, realtime_start: '2026-01-01', realtime_end: '2026-12-31', name: 'CPI', press_release: true, link: 'https://bls.gov' }]
+      };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      );
+
+      const result = await browseReleases();
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.total_releases).toBe(1);
+      expect(parsed.releases[0].name).toBe('CPI');
+    });
+  });
+
+  describe('browseSources', () => {
+    test('returns sources list', async () => {
+      const mockResponse = {
+        count: 1, offset: 0, limit: 50,
+        sources: [{ id: 1, realtime_start: '2026-01-01', realtime_end: '2026-12-31', name: 'BLS', link: 'https://bls.gov' }]
+      };
+
+      (global.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      );
+
+      const result = await browseSources();
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.total_sources).toBe(1);
+      expect(parsed.sources[0].name).toBe('BLS');
+    });
+  });
+});

--- a/test/unit/fred/tools.test.ts
+++ b/test/unit/fred/tools.test.ts
@@ -25,21 +25,24 @@ describe('FRED tools module', () => {
       expect(typeof registerFREDTools).toBe('function');
     });
     
-    test('registers all three tools with the server', () => {
+    test('registers all six tools with the server', () => {
       const mockServer = createMockServer();
       registerFREDTools(mockServer as any);
-      
-      // Verify server.tool was called three times
-      expect(mockServer.tool).toHaveBeenCalledTimes(3);
-      
+
+      // Verify server.tool was called six times
+      expect(mockServer.tool).toHaveBeenCalledTimes(6);
+
       // Get the registered tools
       const toolCalls = mockServer.tool.mock.calls;
       const toolNames = toolCalls.map(call => call[0]);
-      
-      // Verify all three tools are registered
+
+      // Verify all six tools are registered
       expect(toolNames).toContain('fred_browse');
       expect(toolNames).toContain('fred_search');
       expect(toolNames).toContain('fred_get_series');
+      expect(toolNames).toContain('fred_release_dates');
+      expect(toolNames).toContain('fred_series_info');
+      expect(toolNames).toContain('fred_series_tags');
     });
     
     test('fred_browse tool has correct schema', () => {
@@ -96,6 +99,43 @@ describe('FRED tools module', () => {
       expect(schema).toHaveProperty('frequency');
     });
     
+    test('fred_release_dates tool has correct schema', () => {
+      const mockServer = createMockServer();
+      registerFREDTools(mockServer as any);
+
+      const toolCall = mockServer.tool.mock.calls.find(call => call[0] === 'fred_release_dates');
+      expect(toolCall).toBeDefined();
+
+      const schema = toolCall![2];
+      expect(schema).toHaveProperty('release_id');
+      expect(schema).toHaveProperty('limit');
+      expect(schema).toHaveProperty('offset');
+      expect(schema).toHaveProperty('sort_order');
+      expect(schema).toHaveProperty('include_release_dates_with_no_data');
+    });
+
+    test('fred_series_info tool has correct schema', () => {
+      const mockServer = createMockServer();
+      registerFREDTools(mockServer as any);
+
+      const toolCall = mockServer.tool.mock.calls.find(call => call[0] === 'fred_series_info');
+      expect(toolCall).toBeDefined();
+
+      const schema = toolCall![2];
+      expect(schema).toHaveProperty('series_id');
+    });
+
+    test('fred_series_tags tool has correct schema', () => {
+      const mockServer = createMockServer();
+      registerFREDTools(mockServer as any);
+
+      const toolCall = mockServer.tool.mock.calls.find(call => call[0] === 'fred_series_tags');
+      expect(toolCall).toBeDefined();
+
+      const schema = toolCall![2];
+      expect(schema).toHaveProperty('series_id');
+    });
+
     test('all tool handlers are functions', () => {
       const mockServer = createMockServer();
       registerFREDTools(mockServer as any);


### PR DESCRIPTION
## Summary

Adds three new tools that extend the FRED API coverage:

- **`fred_release_dates`** — Get release dates for a specific release (e.g., CPI, GDP, Employment Situation) or all upcoming release dates across all releases. Wraps `/fred/release/dates` and `/fred/releases/dates`. Supports `include_release_dates_with_no_data` for future scheduled releases — essential for economic calendar queries.
- **`fred_series_info`** — Get detailed metadata for a series (title, units, frequency, seasonal adjustment, observation range, popularity, notes). Wraps `/fred/series`.
- **`fred_series_tags`** — Get tags/classifications for a series. Wraps `/fred/series/tags`.

## Motivation

The existing toolset covers catalog browsing, search, and observations, but lacks `release/dates` which is the underlying endpoint needed for upcoming release schedules. `series_info` and `series_tags` are natural additions for understanding series metadata without having to fetch observations.

## Changes

- `src/fred/browse.ts` — Added `getReleaseDates`, `getAllReleaseDates`, `getSeriesInfo`, `getSeriesTags` functions
- `src/fred/tools.ts` — Registered the three new tools with schemas and descriptions
- `test/unit/fred/tools.test.ts` — Updated to verify all 6 tools register with correct schemas
- `test/unit/fred/browse.test.ts` — New test file with unit tests for all new and existing browse functions

All 63 tests pass. Coverage improved (45% stmts, 50% lines, 59% functions — above thresholds).

## Test plan

- [x] `fred_release_dates` with `release_id` (e.g., 10 for CPI) returns historical dates
- [x] `fred_release_dates` without `release_id` returns all upcoming release dates
- [x] `fred_release_dates` with `include_release_dates_with_no_data=true` includes future scheduled dates
- [x] `fred_series_info` with `series_id=GDP` returns full metadata
- [x] `fred_series_tags` with `series_id=UNRATE` returns tag list
- [x] All 63 unit tests pass
- [x] Coverage thresholds met (45% stmts, 50% lines, 59% functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)