### PR TITLE
fix(docker): pin pnpm to the packageManager version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-RUN npm install -g pnpm
+# Pin to the version in package.json's packageManager field: an unpinned
+# pnpm self-substitutes the pinned version as a native @pnpm/exe binary and
+# refuses because it is not in pnpm-lock.yaml
+RUN npm install -g pnpm@10.10.0
 
 COPY package.json pnpm-lock.yaml* ./
 


### PR DESCRIPTION
The v1.2.0 Docker publish failed because the Dockerfile installs unpinned latest pnpm, which self-substitutes the packageManager-pinned 10.10.0 as a native @pnpm/exe binary and aborts since it is not in pnpm-lock.yaml. Pinning the install to 10.10.0 skips the substitution; a local podman build passes. After merging I'll re-create the v1.2.0 tag and release so the publish workflows run with the fix.