### PR TITLE
ci(npm): publish via OIDC trusted publishing

### DIFF
--- a/.github/workflows/github-package.yml
+++ b/.github/workflows/github-package.yml
@@ -87,6 +87,8 @@ jobs:
         run: |
           echo "@stefanoamorelli:registry=https://npm.pkg.github.com/" >> .npmrc
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Update package name for GitHub Packages
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -58,9 +58,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-          
+
+      # Trusted publishing (OIDC) needs npm 11.5.1+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
@@ -85,9 +90,8 @@ jobs:
       - name: Build
         run: pnpm build
         
+      # Authenticates via OIDC trusted publishing (configured on npmjs.com);
+      # provenance is generated automatically, no token involved
       - name: Publish to npm
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
+        run: npm publish --access public
 


### PR DESCRIPTION
The v1.2.0 npm publish failed with a 404 on PUT, npm's way of masking an expired token, and the same step already failed on the previous release attempt, so NPM_TOKEN has been dead for a while. npm is also deprecating 2FA-bypass tokens (Jan 2027 for publishing), so a fresh token would only postpone the same failure. This switches the publish step to OIDC trusted publishing: npm 11.5.1+, no token, automatic provenance. Requires the trusted publisher (repo stefanoamorelli/fred-mcp-server, workflow npm-publish.yml) registered in the package settings on npmjs.com, which is being set up alongside this PR.